### PR TITLE
fix(product-card): drop use of `useCallback()`

### DIFF
--- a/src/app/_components/biz-profile/product-card.tsx
+++ b/src/app/_components/biz-profile/product-card.tsx
@@ -114,7 +114,7 @@ export const EditProductCardDialogContent = ({
   })
   const { control, setValue, getValues } = form
 
-  const onSave = useCallback(async () => {
+  const onSave = async () => {
     const values = getValues()
     if (!product) {
       onProductAdd?.(values)
@@ -122,15 +122,15 @@ export const EditProductCardDialogContent = ({
     } else {
       onProductUpdate?.(values)
     }
-  }, [getValues, onProductUpdate, onProductAdd, product, form])
-  const onDelete = useCallback(() => {
+  }
+  const onDelete = () => {
     if (!product) {
       // do nothing
     } else {
       onProductDelete?.(product.id!)
     }
     form.reset()
-  }, [onProductDelete, product, form])
+  }
 
   return (
     <DialogContent>


### PR DESCRIPTION
We must not use memoisation here, as we must invoke callbacks when the state of the product changes. Memoisation keys on obj refs, so even if the product properties change, the callback refuse firing.